### PR TITLE
Healthcheck-Endpunkt gemäss Anforderung #4 implementiert

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -59,4 +59,9 @@ const waitForSocketState = (socket: WebSocket, state: any) => {
   });
 };
 
+app.get('/healthcheck', (req, res) => {
+  res.status(200).send('OK');
+});
+
+
 export { startServer, waitForSocketState };


### PR DESCRIPTION
Fixes #4

`/healthcheck`-Route implementiert:

- Gibt bei Aufruf HTTP 200 OK zurück
- Antwort: `"OK"`